### PR TITLE
fix the csrf issue when using button upload image

### DIFF
--- a/vendor/assets/javascripts/redactor-rails/redactor.js
+++ b/vendor/assets/javascripts/redactor-rails/redactor.js
@@ -2942,7 +2942,11 @@ var RLANG = {
 			{
 				var formId = 'redactorUploadForm' + this.id;
 				var fileId = 'redactorUploadFile' + this.id;
-				this.form = $('<form  action="' + this.uploadOptions.url + '" method="POST" target="' + name + '" name="' + formId + '" id="' + formId + '" enctype="multipart/form-data"></form>');
+				this.form = $('<form  action="' + this.uploadOptions.url + 
+					'" method="POST" target="' + name + '" name="' + formId + '" id="' + formId + 
+					'" enctype="multipart/form-data"><input type="hidden" name="authenticity_token" value="' +
+					$('meta[name="csrf-token"]').attr('content') +
+					'"></form>');
 				
 				var oldElement = this.uploadOptions.input;
 				var newElement = $(oldElement).clone();


### PR DESCRIPTION
Fix this issue by simply add a hidden input to the upload form. It will only works with <%= csrf_meta_tags %> present in layout.

redactor.js is changed but redactor.min.js is not, because I don't know which tool you are using for compressing.
