### PR TITLE
Make :file the default storage with reminder that :fog is available

### DIFF
--- a/lib/generators/redactor/templates/base/carrierwave/uploaders/redactor_rails_document_uploader.rb
+++ b/lib/generators/redactor/templates/base/carrierwave/uploaders/redactor_rails_document_uploader.rb
@@ -2,7 +2,8 @@
 class RedactorRailsDocumentUploader < CarrierWave::Uploader::Base
   include RedactorRails::Backend::CarrierWave
 
-  storage :fog
+  # storage :fog
+  storage :file
 
   def store_dir
     "system/redactor_assets/documents/#{model.id}"


### PR DESCRIPTION
For consistency with the picture uploader, sorry 'bout that
