### PR TITLE
Address a bug where as_json triggered thumb, url(:thumb) on Document

### DIFF
--- a/lib/generators/redactor/templates/mongoid/carrierwave/redactor/document.rb
+++ b/lib/generators/redactor/templates/mongoid/carrierwave/redactor/document.rb
@@ -4,4 +4,11 @@ class RedactorRails::Document < RedactorRails::Asset
   def url_content
     url(:content)
   end
+
+  def thumb
+    # Could theoretically provide an icon set here
+    # to match against the extensions
+    # but for now it's nil to address the bug
+    nil
+  end
 end


### PR DESCRIPTION
When trying to get Documents as json through the `fileGetJson` option, an ArgumentError was raised because Documents don't have thumbs

In the future, this method could return URLs to icons matching the extension of the file

For now, the bug must be fixed ; )
