### PR TITLE
Added ability to define the Devise User class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,64 @@ and
 Add to your layout
 
     <%= redactor_lang('zh_tw') %>
+    
+### Defining a Devise User Model
 
+By default redactor-rails uses the `User` model.
+
+You may use a different model by:
+
+1. Run a migration to update the user_id column in the 
+2. Overriding the user class in an initializer.
+3. Overriding the authentication helpers in your controller.
+
+    Create a new Migration: `rails g rename_user_id_to_new_user_id`
+    
+    ```
+    # db/migrate/...rename_user_id_to_new_user_id.rb
+    
+    class RenameUserIdToNewUserId < ActiveRecord::Migration
+      def up
+        rename_column :redactor_assets, :user_id, :admin_user_id
+      end
+    
+      def down
+        rename_column :redactor_assets, :admin_user_id, :user_id
+      end
+    end
+    ```
+
+    ```
+    # config/redactor.rb
+    # Overrides the user class
+    
+    module RedactorRails
+      def self.devise_user
+        %s(admin_user) # name of your user class
+      end
+      
+      # You may override this to support legacy schema.
+      # def self.devise_user_key
+      #   "#{self.devise_user.to_s}_id".to_sym
+      # end
+    end
+    ```
+    
+    ```
+    # app/controllers/application_controller.rb
+    
+    class ApplicationController < ActionController::Base
+      ...
+      
+      def redactor_authenticate_user!
+        authenticate_admin_user! # devise before_filter
+      end
+    
+      def redactor_current_user
+        current_admin_user # devise user helper
+      end
+    end
+    ```
 
 ## Contributing
 

--- a/app/controller/redactor_rails/documents_controller.rb
+++ b/app/controller/redactor_rails/documents_controller.rb
@@ -1,9 +1,9 @@
 class RedactorRails::DocumentsController < ApplicationController
-  before_filter :authenticate_user! if RedactorRails.document_model.new.respond_to?(:user_id)
+  before_filter :redactor_authenticate_user! if RedactorRails.document_model.new.respond_to?(RedactorRails.devise_user)
 
   def index
     @documents = RedactorRails.document_model.where(
-        RedactorRails.document_model.new.respond_to?(:user_id) ? { user_id: current_user.id } : { })
+        RedactorRails.document_model.new.respond_to?(RedactorRails.devise_user) ? { RedactorRails.devise_user_key => redactor_current_user.id } : { })
     render :json => @documents.to_json
   end
 
@@ -12,9 +12,9 @@ class RedactorRails::DocumentsController < ApplicationController
 
     file = params[:file]
     @document.data = RedactorRails::Http.normalize_param(file, request)
-    if @document.respond_to?(:user_id)
-      @document.user = current_user
-      @document.assetable = current_user
+    if @document.respond_to?(RedactorRails.devise_user)
+      @document.send("#{RedactorRails.devise_user}=", redactor_current_user)
+      @document.assetable = redactor_current_user
     end
 
     if @document.save

--- a/app/controller/redactor_rails/pictures_controller.rb
+++ b/app/controller/redactor_rails/pictures_controller.rb
@@ -1,9 +1,9 @@
 class RedactorRails::PicturesController < ApplicationController
-  before_filter :authenticate_user! if RedactorRails.picture_model.new.respond_to?(:user_id)
+  before_filter :redactor_authenticate_user! if RedactorRails.picture_model.new.respond_to?(RedactorRails.devise_user)
 
   def index
     @pictures = RedactorRails.picture_model.where(
-        RedactorRails.picture_model.new.respond_to?(:user_id) ? { user_id: current_user.id } : { })
+        RedactorRails.picture_model.new.respond_to?(RedactorRails.devise_user) ? { RedactorRails.devise_user_key => redactor_current_user.id } : { })
     render :json => @pictures.to_json
   end
 
@@ -12,9 +12,9 @@ class RedactorRails::PicturesController < ApplicationController
 
     file = params[:file]
     @picture.data = RedactorRails::Http.normalize_param(file, request)
-    if @picture.respond_to?(:user_id)
-      @picture.user = current_user
-      @picture.assetable = current_user
+    if @picture.respond_to?(RedactorRails.devise_user)
+      @picture.send("#{RedactorRails.devise_user}=", redactor_current_user)
+      @picture.assetable = redactor_current_user
     end
 
     if @picture.save

--- a/lib/redactor-rails.rb
+++ b/lib/redactor-rails.rb
@@ -7,6 +7,7 @@ module RedactorRails
   FILE_TYPES = ['application/msword', 'application/pdf', 'text/plain', 'text/rtf', 'application/vnd.ms-excel']
 
   autoload :Http, 'redactor-rails/http'
+  autoload :Devise, 'redactor-rails/devise'
 
   module Backend
     autoload :CarrierWave, 'redactor-rails/backend/carrierwave'
@@ -28,5 +29,13 @@ module RedactorRails
 
   def self.document_model
     RedactorRails::Document
+  end
+
+  def self.devise_user
+    %s(user)
+  end
+
+  def self.devise_user_key
+    "#{self.devise_user.to_s}_id".to_sym
   end
 end

--- a/lib/redactor-rails/devise.rb
+++ b/lib/redactor-rails/devise.rb
@@ -1,0 +1,11 @@
+module RedactorRails
+  module Devise
+    def redactor_authenticate_user!
+      authenticate_user!
+    end
+
+    def redactor_current_user
+      current_user
+    end
+  end
+end

--- a/lib/redactor-rails/engine.rb
+++ b/lib/redactor-rails/engine.rb
@@ -3,8 +3,12 @@ module RedactorRails
     isolate_namespace RedactorRails
     initializer "helper" do |app|
       ActiveSupport.on_load(:action_view) do
-	include RedactorRails::Helpers
+        include RedactorRails::Helpers
       end
+    end
+
+    initializer "redactor_devise" do |app|
+      ActionController::Base.send :include, RedactorRails::Devise
     end
   end
 end

--- a/lib/redactor-rails/orm/active_record.rb
+++ b/lib/redactor-rails/orm/active_record.rb
@@ -15,7 +15,7 @@ module RedactorRails
               self.table_name = "redactor_assets"
 
               belongs_to :assetable, :polymorphic => true
-              belongs_to :user,      :dependent   => :destroy
+              belongs_to RedactorRails.devise_user, :dependent => :destroy, :foreign_key => RedactorRails.devise_user_key
 
               attr_accessible :data, :assetable_type, :assetable_id, :assetable
             end


### PR DESCRIPTION
The filters and helpers are hard coded to use the User model. If you are using a model class anything else, the filters will fail. 

Example:

```
# User.rb
authenticate_user!
current_user

# AdminUser.rb 
authenticate_admin_user!
current_admin_user
```

Instructions are at the bottom of the README.
