### PR TITLE
Remove thumb from Document's json methods

### DIFF
--- a/lib/generators/redactor/templates/active_record/carrierwave/redactor/document.rb
+++ b/lib/generators/redactor/templates/active_record/carrierwave/redactor/document.rb
@@ -4,4 +4,8 @@ class RedactorRails::Document < RedactorRails::Asset
   def url_content
     url(:content)
   end
+
+  def as_json_methods
+    [:image]
+  end
 end


### PR DESCRIPTION
This fixes a bug where the Documents#Index JSON failed because there is no "thumb" url for documents

This ties into an earlier PR where we suggested in the future documents could have thumbs based on their file extensions. That would be cool.
