### PR TITLE
Do not destroy associated user on destroy RedactorRails::Asset models

### DIFF
--- a/lib/redactor-rails/orm/active_record.rb
+++ b/lib/redactor-rails/orm/active_record.rb
@@ -15,7 +15,7 @@ module RedactorRails
               self.table_name = "redactor_assets"
 
               belongs_to :assetable, :polymorphic => true
-              belongs_to RedactorRails.devise_user, :dependent => :destroy, :foreign_key => RedactorRails.devise_user_key
+              belongs_to RedactorRails.devise_user, :foreign_key => RedactorRails.devise_user_key
 
               if defined?(ActiveModel::ForbiddenAttributesProtection) && base.ancestors.include?(ActiveModel::ForbiddenAttributesProtection)
                 # Ok


### PR DESCRIPTION
``` ruby
class RedactorRails::Asset
  belongs_to :user, :dependent => :destroy
end

RedactorRails::Asset.destroy_all
```

the code above destroys users, associated with the RedactorRails::Asset models. Fixed
