### PR TITLE
Added plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,37 @@ Add to your `application.js`:
 
     //= require redactor-rails/langs/zh_tw
 
+### Using plugins
+
+This gem comes bundled with several Redactor plugins:
+
+- Fullscreen
+- Clips
+- FontColor
+- FontSize
+- FontFamily
+- Text direction
+ 
+Full details of these can be found at [Redactor Plugins](http://imperavi.com/redactor/docs/plugins/)
+
+To include all the plugins just add to your `application.js`:
+      
+        //= require redactor-rails/plugins
+
+and add to your `application.css`:
+
+        *= redactor-rails/plugins
+
+If you would prefer to pick and choose which plugins to include you can
+add for example:
+
+      //= require redactor-rails/plugins/fontsize
+      //= require redactor-rails/plugins/fontfamily
+
+After including the desired plugins they can be configured in the
+redactor config file as normal.
+
+
 ### Defining a Devise User Model
 
 By default redactor-rails uses the `User` model.

--- a/vendor/assets/javascripts/redactor-rails/plugins.js
+++ b/vendor/assets/javascripts/redactor-rails/plugins.js
@@ -1,0 +1,6 @@
+//= require redactor-rails/plugins/clips
+//= require redactor-rails/plugins/fontcolor
+//= require redactor-rails/plugins/fontfamily
+//= require redactor-rails/plugins/fontsize
+//= require redactor-rails/plugins/fullscreen
+//= require redactor-rails/plugins/textdirection

--- a/vendor/assets/javascripts/redactor-rails/plugins/clips.js
+++ b/vendor/assets/javascripts/redactor-rails/plugins/clips.js
@@ -1,0 +1,35 @@
+if (!RedactorPlugins) var RedactorPlugins = {};
+
+RedactorPlugins.clips = {
+	init: function()
+	{
+		var callback = $.proxy(function()
+		{
+			$('#redactor_modal').find('.redactor_clip_link').each($.proxy(function(i, s)
+			{
+				$(s).click($.proxy(function()
+				{
+					this.insertClip($(s).next().html());
+					return false;
+
+				}, this));
+			}, this));
+
+			this.selectionSave();
+			this.bufferSet();
+
+		}, this );
+
+		this.buttonAdd('clips', 'Clips', function(e)
+		{
+			this.modalInit('Clips', '#clipsmodal', 500, callback);
+		});
+	},
+	insertClip: function(html)
+	{
+		this.selectionRestore();
+		this.insertHtml($.trim(html));
+		this.modalClose();
+	}
+};
+

--- a/vendor/assets/javascripts/redactor-rails/plugins/fontcolor.js
+++ b/vendor/assets/javascripts/redactor-rails/plugins/fontcolor.js
@@ -1,0 +1,73 @@
+if (!RedactorPlugins) var RedactorPlugins = {};
+
+RedactorPlugins.fontcolor = {
+	init: function()
+	{
+		var colors = ['#ffffff', '#000000', '#eeece1', '#1f497d', '#4f81bd', '#c0504d', '#9bbb59', '#8064a2', '#4bacc6', '#f79646', '#ffff00', '#f2f2f2', '#7f7f7f', '#ddd9c3', '#c6d9f0', '#dbe5f1', '#f2dcdb', '#ebf1dd', '#e5e0ec', '#dbeef3', '#fdeada', '#fff2ca', '#d8d8d8', '#595959', '#c4bd97', '#8db3e2', '#b8cce4', '#e5b9b7', '#d7e3bc', '#ccc1d9', '#b7dde8', '#fbd5b5', '#ffe694', '#bfbfbf', '#3f3f3f', '#938953', '#548dd4', '#95b3d7', '#d99694', '#c3d69b', '#b2a2c7', '#b7dde8', '#fac08f', '#f2c314', '#a5a5a5', '#262626', '#494429', '#17365d', '#366092', '#953734', '#76923c', '#5f497a', '#92cddc', '#e36c09', '#c09100', '#7f7f7f', '#0c0c0c', '#1d1b10', '#0f243e', '#244061', '#632423', '#4f6128', '#3f3151', '#31859b', '#974806', '#7f6000'];
+		var buttons = ['fontcolor', 'backcolor'];
+
+		this.buttonAddSeparator();
+
+		for (var i = 0; i < 2; i++)
+		{
+			var name = buttons[i];
+
+			var $dropdown = $('<div class="redactor_dropdown redactor_dropdown_box_' + name + '" style="display: none; width: 210px;">');
+
+			this.pickerBuild($dropdown, name, colors);
+			$(this.$toolbar).append($dropdown);
+
+			this.buttonAdd(name, this.opts.curLang[name], $.proxy(function(btnName, $button, btnObject, e)
+			{
+				this.dropdownShow(e, btnName);
+
+			}, this));
+		}
+	},
+	pickerBuild: function($dropdown, name, colors)
+	{
+		var rule = 'color';
+		if (name === 'backcolor') rule = 'background-color';
+
+		var _self = this;
+		var onSwatch = function(e)
+		{
+			e.preventDefault();
+
+			var $this = $(this);
+			_self.pickerSet($this.data('rule'), $this.attr('rel'));
+
+		}
+
+		var len = colors.length;
+		for (var z = 0; z < len; z++)
+		{
+			var color = colors[z];
+
+			var $swatch = $('<a rel="' + color + '" data-rule="' + rule +'" href="#" style="float: left; font-size: 0; border: 2px solid #fff; padding: 0; margin: 0; width: 15px; height: 15px;"></a>');
+			$swatch.css('background-color', color);
+			$dropdown.append($swatch);
+			$swatch.on('click', onSwatch);
+		}
+
+		var $elNone = $('<a href="#" style="display: block; clear: both; padding: 4px 0; font-size: 11px; line-height: 1;"></a>')
+		.html(this.opts.curLang.none)
+		.on('click', function(e)
+		{
+			e.preventDefault();
+			_self.pickerSet(rule, false);
+		});
+
+		$dropdown.append($elNone);
+	},
+	pickerSet: function(rule, type)
+	{
+		this.bufferSet();
+
+		this.$editor.focus();
+		this.inlineRemoveStyle(rule);
+		if (type !== false) this.inlineSetStyle(rule, type);
+		if (this.opts.air) this.$air.fadeOut(100);
+		this.sync();
+	}
+};

--- a/vendor/assets/javascripts/redactor-rails/plugins/fontfamily.js
+++ b/vendor/assets/javascripts/redactor-rails/plugins/fontfamily.js
@@ -1,0 +1,27 @@
+if (!RedactorPlugins) var RedactorPlugins = {};
+
+RedactorPlugins.fontfamily = {
+	init: function ()
+	{
+		var fonts = [ 'Arial', 'Helvetica', 'Georgia', 'Times New Roman', 'Monospace' ];
+		var that = this;
+		var dropdown = {};
+
+		$.each(fonts, function(i, s)
+		{
+			dropdown['s' + i] = { title: s, callback: function() { that.setFontfamily(s); }};
+		});
+
+		dropdown['remove'] = { title: 'Remove font', callback: function() { that.resetFontfamily(); }};
+
+		this.buttonAdd('fontfamily', 'Change font family', false, dropdown);
+	},
+	setFontfamily: function (value)
+	{
+		this.inlineSetStyle('font-family', value);
+	},
+	resetFontfamily: function()
+	{
+		this.inlineRemoveStyle('font-family');
+	}
+};

--- a/vendor/assets/javascripts/redactor-rails/plugins/fontsize.js
+++ b/vendor/assets/javascripts/redactor-rails/plugins/fontsize.js
@@ -1,0 +1,27 @@
+if (!RedactorPlugins) var RedactorPlugins = {};
+
+RedactorPlugins.fontsize = {
+	init: function()
+	{
+		var fonts = [10, 11, 12, 14, 16, 18, 20, 24, 28, 30];
+		var that = this;
+		var dropdown = {};
+
+		$.each(fonts, function(i, s)
+		{
+			dropdown['s' + i] = { title: s + 'px', callback: function() { that.setFontsize(s); } };
+		});
+
+		dropdown['remove'] = { title: 'Remove font size', callback: function() { that.resetFontsize(); } };
+
+		this.buttonAdd( 'fontsize', 'Change font size', false, dropdown);
+	},
+	setFontsize: function(size)
+	{
+		this.inlineSetStyle('font-size', size + 'px');
+	},
+	resetFontsize: function()
+	{
+		this.inlineRemoveStyle('font-size');
+	}
+};

--- a/vendor/assets/javascripts/redactor-rails/plugins/fullscreen.js
+++ b/vendor/assets/javascripts/redactor-rails/plugins/fullscreen.js
@@ -1,0 +1,146 @@
+if (!RedactorPlugins) var RedactorPlugins = {};
+
+RedactorPlugins.fullscreen = {
+	init: function()
+	{
+		this.fullscreen = false;
+
+		this.buttonAdd('fullscreen', 'Fullscreen', $.proxy(this.toggleFullscreen, this));
+		this.buttonSetRight('fullscreen');
+
+		if (this.opts.fullscreen) this.toggleFullscreen();
+	},
+	toggleFullscreen: function()
+	{
+		var html;
+
+		if (!this.fullscreen)
+		{
+			this.buttonChangeIcon('fullscreen', 'normalscreen');
+			this.buttonActive('fullscreen');
+			this.fullscreen = true;
+
+			if (this.opts.toolbarExternal)
+			{
+				this.toolcss = {};
+				this.boxcss = {};
+				this.toolcss.width = this.$toolbar.css('width');
+				this.toolcss.top = this.$toolbar.css('top');
+				this.toolcss.position = this.$toolbar.css('position');
+				this.boxcss.top = this.$box.css('top');
+			}
+
+			this.fsheight = this.$editor.height();
+
+			if (this.opts.iframe) html = this.get();
+
+			this.tmpspan = $('<span></span>');
+			this.$box.addClass('redactor_box_fullscreen').after(this.tmpspan);
+
+			$('body, html').css('overflow', 'hidden');
+			$('body').prepend(this.$box);
+
+			if (this.opts.iframe) this.fullscreenIframe(html);
+
+			this.fullScreenResize();
+			$(window).resize($.proxy(this.fullScreenResize, this));
+			$(document).scrollTop(0, 0);
+
+			this.focus();
+			this.observeStart();
+
+		}
+		else
+		{
+			this.buttonRemoveIcon('fullscreen', 'normalscreen');
+			this.buttonInactive('fullscreen');
+			this.fullscreen = false;
+
+			$(window).off('resize', $.proxy(this.fullScreenResize, this));
+			$('body, html').css('overflow', '');
+
+			this.$box.removeClass('redactor_box_fullscreen').css({ width: 'auto', height: 'auto' });
+
+			if (this.opts.iframe) html = this.$editor.html();
+			this.tmpspan.after(this.$box).remove();
+
+			if (this.opts.iframe) this.fullscreenIframe(html);
+			else this.sync();
+
+			var height = this.fsheight;
+			if (this.opts.autoresize) height = 'auto';
+
+			if (this.opts.toolbarExternal)
+			{
+				this.$box.css('top', this.boxcss.top);
+				this.$toolbar.css({
+					'width': this.toolcss.width,
+					'top': this.toolcss.top,
+					'position': this.toolcss.position
+				});
+			}
+
+			if (!this.opts.iframe) this.$editor.css('height', height);
+			else this.$frame.css('height', height);
+
+			this.$editor.css('height', height);
+			this.focus();
+			this.observeStart();
+		}
+	},
+	fullscreenIframe: function(html)
+	{
+		this.$editor = this.$frame.contents().find('body').attr({
+			'contenteditable': true,
+			'dir': this.opts.direction
+		});
+
+		// set document & window
+		if (this.$editor[0])
+		{
+			this.document = this.$editor[0].ownerDocument;
+			this.window = this.document.defaultView || window;
+		}
+
+		// iframe css
+		this.iframeAddCss();
+
+		if (this.opts.fullpage) this.setFullpageOnInit(html);
+		else this.set(html);
+
+		if (this.opts.wym) this.$editor.addClass('redactor_editor_wym');
+	},
+	fullScreenResize: function()
+	{
+		if (!this.fullscreen) return false;
+
+		var toolbarHeight = this.$toolbar.height();
+
+		var pad = this.$editor.css('padding-top').replace('px', '');
+		var height = $(window).height() - toolbarHeight;
+		this.$box.width($(window).width() - 2).height(height + toolbarHeight);
+
+		if (this.opts.toolbarExternal)
+		{
+			this.$toolbar.css({
+				'top': '0px',
+				'position': 'absolute',
+				'width': '100%'
+			});
+
+			this.$box.css('top', toolbarHeight + 'px');
+		}
+
+		if (!this.opts.iframe) this.$editor.height(height - (pad * 2));
+		else
+		{
+			setTimeout($.proxy(function()
+			{
+				this.$frame.height(height);
+
+			}, this), 1);
+		}
+
+		this.$editor.height(height);
+	}
+};

--- a/vendor/assets/javascripts/redactor-rails/plugins/textdirection.js
+++ b/vendor/assets/javascripts/redactor-rails/plugins/textdirection.js
@@ -1,0 +1,24 @@
+if (!RedactorPlugins) var RedactorPlugins = {};
+
+RedactorPlugins.textdirection = {
+	init: function()
+	{
+		var that = this;
+		var dropdown = {};
+
+		dropdown['ltr'] = { title: 'Left to right', callback: function () { that.ltrTextDirection(); } };
+		dropdown['rtl'] = { title: 'Right to left', callback: function () { that.rtlTextDirection(); } };
+
+		this.buttonAdd('direction', 'Change direction', false, dropdown);
+	},
+	rtlTextDirection: function()
+	{
+		this.bufferSet();
+		this.blockSetAttr('dir', 'rtl');
+	},
+	ltrTextDirection: function()
+	{
+		this.bufferSet();
+		this.blockRemoveAttr('dir');
+	}
+};

--- a/vendor/assets/stylesheets/redactor-rails/plugins.css
+++ b/vendor/assets/stylesheets/redactor-rails/plugins.css
@@ -1,0 +1,3 @@
+/*
+*= require redactor-rails/plugins/clips
+*/

--- a/vendor/assets/stylesheets/redactor-rails/plugins/clips.css
+++ b/vendor/assets/stylesheets/redactor-rails/plugins/clips.css
@@ -1,0 +1,34 @@
+.label-red {
+	color: #fff;
+	background: #c92020;
+	padding: 0 7px;
+	border-radius: 4px;
+}
+
+.redactor_clips_box {
+	margin-left: 0;
+	padding-left: 0;
+	list-style: none;
+	max-height: 250px;
+	overflow-x: scroll;
+}
+.redactor_clips_box li {
+	border-top: 1px solid #fff;
+	border-bottom: 1px solid #ddd;
+}
+.redactor_clips_box li:first-child {
+	border-top: none;
+}
+.redactor_clips_box li:last-child {
+	border-bottom: none;
+}
+.redactor_clips_box li a {
+	padding: 10px 5px;
+	color: #000;
+	text-decoration: none;
+	font-size: 13px;
+	display: block;
+}
+.redactor_clips_box li a:hover {
+	background-color: #fff;
+}


### PR DESCRIPTION
Hey, I noticed that the gem doesn't currently include any of the useful plugins listed at the redactor website. I've added these to their own folders in the vendor directory and created import files so that it is easy to either include all the plugins or pick and choose which plugins to include.

By default this will not include the plugins and they will only get added as the user requests these. I think this would be great to have as I tend to use the plugins often and hate having to download and include the files for them manually.

Could you have a look through my commit below and merge if appropriate, if not I'd appreciate feedback.

Thanks
.FxN
