### PR TITLE
Avoid method name collision

### DIFF
--- a/lib/generators/redactor/install_generator.rb
+++ b/lib/generators/redactor/install_generator.rb
@@ -38,7 +38,7 @@ module Redactor
   end
       end
 
-      def create_migration
+      def create_redactor_migration
         if orm.to_s == "active_record"
           if ARGV.include?('--devise')
             migration_template "#{generator_dir}/devise_migration.rb", File.join('db/migrate', "create_redactor_assets.rb")


### PR DESCRIPTION
Command:
`rails generate redactor:install`
throws an error.

Since Rails 4.0.4 there is a method called create_migration in Rails::Generators::Migration. Changing the name solves this problem.
