### PR TITLE
Replace before_filter with before_action

### DIFF
--- a/app/controller/redactor_rails/documents_controller.rb
+++ b/app/controller/redactor_rails/documents_controller.rb
@@ -1,5 +1,5 @@
 class RedactorRails::DocumentsController < ApplicationController
-  before_filter :redactor_authenticate_user!
+  before_action :redactor_authenticate_user!
 
   def index
     @documents = RedactorRails.document_model.where(

--- a/app/controller/redactor_rails/pictures_controller.rb
+++ b/app/controller/redactor_rails/pictures_controller.rb
@@ -1,5 +1,5 @@
 class RedactorRails::PicturesController < ApplicationController
-  before_filter :redactor_authenticate_user!
+  before_action :redactor_authenticate_user!
 
   def index
     @pictures = RedactorRails.picture_model.where(


### PR DESCRIPTION
Hey!

I'm using this gem on Rails 5.0, so it says `before_filter is deprecated and will be removed on Rails 5.1. Try to use before_action instead`

The aim of this PR is to avoid this deprecation message

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sammylin/redactor-rails/152)

<!-- Reviewable:end -->
