### PR TITLE
Allow non-standard devise user class names

### DIFF
--- a/lib/redactor-rails.rb
+++ b/lib/redactor-rails.rb
@@ -38,4 +38,8 @@ module RedactorRails
   def self.devise_user_key
     "#{self.devise_user.to_s}_id".to_sym
   end
+
+  def self.devise_user_class_name
+    "User"
+  end
 end

--- a/lib/redactor-rails/orm/active_record.rb
+++ b/lib/redactor-rails/orm/active_record.rb
@@ -15,7 +15,7 @@ module RedactorRails
               self.table_name = "redactor_assets"
 
               belongs_to :assetable, :polymorphic => true
-              belongs_to RedactorRails.devise_user, :foreign_key => RedactorRails.devise_user_key
+              belongs_to RedactorRails.devise_user, :foreign_key => RedactorRails.devise_user_key, :class_name => RedactorRails.devise_user_class_name
 
               if defined?(ActiveModel::ForbiddenAttributesProtection) && base.ancestors.include?(ActiveModel::ForbiddenAttributesProtection)
                 # Ok


### PR DESCRIPTION
I have my `User` class in a namespaced Engine called `Accounts`, so I need to override the belongs_to association as `class_name: "Accounts::User"` in a `redactor.rb` file.

The current configuration allows for differently named User classes, via foreign-key inference, but doesn't allow for namespaced User classes. This commit adds support for namespaced User models.

In my app, I first monkey patched this code change, and now I'm using my branch in my Gemfile.